### PR TITLE
🐛(project) fix bootstrap target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ list-meetings: ## List meetings running on the BBB server
 
 bootstrap: ## Prepare Docker images for the project
 bootstrap: \
-	build \
-	.env
+	.env \
+	build
 .PHONY: bootstrap
 
 # -- Build tools


### PR DESCRIPTION
## Purpose

On a fresh environment, the `make bootstrap` command fails with the following error : `Couldn't find env file`. The `.env` file must be generated before building the docker image.

## Proposal

Fix the `bootstrap` task.
