### PR TITLE
🐛(stress-test) fix echo test dialog handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `cli.js list-meeting` command to list the meetings running on a BBB instance
 - `cli.js stress` command to start a stress test on a BBB server
 
+### Fixed
+
+- handle echo test dialog when microphone is active
+
 [Unreleased]: https://github.com/openfun/bbb-stress-test

--- a/lib/stress-test.js
+++ b/lib/stress-test.js
@@ -13,10 +13,23 @@ const initClient = async (
   await page.goto(joinUrl);
   const audioAction = microphone ? "Microphone" : "Listen only";
   logger.debug(`waiting for audio prompt ([aria-label="${audioAction}"])`);
-  await page.pdf({ path: "/tmp/test1.pdf" });
   await page.waitForSelector(`[aria-label="${audioAction}"]`);
   logger.debug(`click on ${audioAction}`);
   await page.click(`[aria-label="${audioAction}"]`);
+  if (microphone) {
+    logger.debug("waiting for the echo test dialog");
+    try {
+      await page.waitForSelector(`[aria-label="Echo is audible"]`);
+      logger.debug(
+        'echo test dialog detected. clicking on "Echo is audible" button.'
+      );
+      await page.click(`[aria-label="Echo is audible"]`);
+    } catch (err) {
+      logger.debug(
+        "unable to detect the echo test dialog. Maybe echo test is disabled."
+      );
+    }
+  }
   await page.waitForSelector(".ReactModal__Overlay", { hidden: true });
   if (microphone) {
     logger.debug("Ensure that we are not muted...");


### PR DESCRIPTION
## Purpose

The initial version of bbb-stress-test was developped and tested with
a BBB instance configured with echo test disabled. As a result, it
does not work on a standard BBB installation.

## Proposal

Handle the echo test dialog in the puppeteer script when the microphone is active.

## Fixes

#3 
