### PR TITLE
🐛(stress-test) fix invalid mute status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - handle echo test dialog when microphone is active
+- invalid mute status when microphone is active
 
 [Unreleased]: https://github.com/openfun/bbb-stress-test

--- a/lib/stress-test.js
+++ b/lib/stress-test.js
@@ -35,17 +35,10 @@ const initClient = async (
     logger.debug("Ensure that we are not muted...");
     // Wait for the toolbar to appear
     await page.waitForSelector('[aria-label="Mute"],[aria-label="Unmute"]');
-    // In any case, click on the mute button
-    // (even if we are muted, the "Mute" button shows up when joining a conference)
-    logger.debug("First click on Mute button to check our real mute status");
-    const muteButton = await page.$('[aria-label="Mute"]');
-    if (muteButton !== null) {
-      await muteButton.click();
-    }
     // If we are muted, click on Unmute
     const unmuteButton = await page.$('[aria-label="Unmute"]');
     if (unmuteButton !== null) {
-      logger.debug("Click on Unmute");
+      logger.debug("clicking on unmute button");
       await unmuteButton.click();
     }
   }


### PR DESCRIPTION
## Purpose

Puppeteer clients connecting with an active microphone are muted.

## Proposal

Fix mute status detection.
It works whatever the value of the room setting «Mute users when they join» is.