### PR TITLE
fixed lodash version, added autoShareWebcam option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - handle echo test dialog when microphone is active
 - invalid mute status when microphone is active
+- autoShareWebcam setting detected
 
 [Unreleased]: https://github.com/openfun/bbb-stress-test

--- a/lib/stress-test.js
+++ b/lib/stress-test.js
@@ -10,6 +10,18 @@ const initClient = async (
   microphone = false
 ) => {
   const page = await browser.newPage();
+  await page.evaluateOnNewDocument(() => {
+    Object.defineProperty(navigator, "language", {
+      get: function () {
+        return "en-US";
+      },
+    });
+    Object.defineProperty(navigator, "languages", {
+      get: function () {
+        return ["en-US", "en"];
+      },
+    });
+  });
   await page.goto(joinUrl);
   const audioAction = microphone ? "Microphone" : "Listen only";
   logger.debug(`waiting for audio prompt ([aria-label="${audioAction}"])`);
@@ -43,11 +55,17 @@ const initClient = async (
     }
   }
   if (webcam) {
-    await page.waitForSelector('[aria-label="Share webcam"]');
-    await page.click('[aria-label="Share webcam"]');
-    logger.debug("clicked on sharing webcam");
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    await page.waitForSelector("#setCam > option");
+    let shareWebcam = await page.$("#setCam > option");
+    if (shareWebcam == null) {
+      logger.debug("sharing webcam has to be clicked");
+      await page.waitForSelector('[aria-label="Share webcam"]');
+      await page.click('[aria-label="Share webcam"]');
+      logger.debug("clicked on sharing webcam");
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await page.waitForSelector("#setCam > option");
+    } else {
+      logger.debug("autoShareWebcam is enabled");
+    }
     await page.waitForSelector('[aria-label="Start sharing"]');
     logger.debug("clicking on start sharing");
     await page.click('[aria-label="Start sharing"]');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/openfun/bbb-stress-test#readme",
   "dependencies": {
     "bigbluebutton-js": "0.0.7",
-    "lodash": "4.17.15",
+    "lodash": "4.17.21",
     "puppeteer": "4.0.0",
     "winston": "3.2.1",
     "yargs": "15.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,7 +380,12 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash@4.17.15, lodash@^4.17.14:
+lodash@4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
- the previous lodash version fails with error `Error: Cannot find module 'lodash/fp'`, because of that I updated the version 4.17.21
- if you have enabled `autoShareWebcam`, then the script will fail to start the webcam. In the new version the `#setCam > option` selector is checked first, and if it is already there it's not needed to click the share video button.