### PR TITLE
version dump of node docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim as core
+FROM node:19-slim as core
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer


### PR DESCRIPTION
Closes #19 

Using `node:19-slim` as parent image google-chrome-unstable can be installed and the stress test can be executed.